### PR TITLE
Amendment to sunspotzooniverse_pair2images.csv

### DIFF
--- a/python/sunspotzooniverse_pair2images.csv
+++ b/python/sunspotzooniverse_pair2images.csv
@@ -1,6 +1,4 @@
-#Image index to pair index mapping.
-#pair_index, image_a, image_b
-#
+pair_index, image_a, image_b
 0, 0, 1
 1, 0, 2
 2, 0, 3


### PR DESCRIPTION
Removed the line `#Image index to pair index mapping` as well as the orphaned `#`s under that line to make it slightly more painless to read this file programatically. Also I think the title might be enough to explain what this file does (pair2images) hence my suggestion to remove the in-file description 😄 